### PR TITLE
Sync with the gbm API to import FD with modifier

### DIFF
--- a/gralloc_gbm.cpp
+++ b/gralloc_gbm.cpp
@@ -132,10 +132,8 @@ static struct gralloc_gbm_bo_t *gbm_import(struct gbm_device *gbm,
 		return NULL;
 	}
 
-	data.fd = handle->prime_fd;
 	data.width = handle->width;
 	data.height = handle->height;
-	data.stride = handle->stride;
 	data.format = format;
 	/* Adjust the width and height for a GBM GR88 buffer */
 	if (handle->format == HAL_PIXEL_FORMAT_YV12) {
@@ -144,9 +142,14 @@ static struct gralloc_gbm_bo_t *gbm_import(struct gbm_device *gbm,
 	}
 
 	#ifdef GBM_BO_IMPORT_FD_MODIFIER
+	data.num_fds = 1;
+	data.fds[0] = handle->prime_fd;
+	data.strides[0] = handle->stride;
 	data.modifier = handle->modifier;
 	buf->bo = gbm_bo_import(gbm, GBM_BO_IMPORT_FD_MODIFIER, &data, 0);
 	#else
+	data.fd = handle->prime_fd;
+	data.stride = handle->stride;
 	buf->bo = gbm_bo_import(gbm, GBM_BO_IMPORT_FD, &data, 0);
 	#endif
 	if (!buf->bo) {


### PR DESCRIPTION
Commit 4026744fcb31f1d27c1b32e6945aadd4da415c6d in mesa introduced an
updated `struct gbm_import_fd_modifier_data' with arrays for fds,
strides and offsets, instead of single values.

Fix just by specifying one single item in the arrays.

Signed-off-by: Aleksander Morgado <aleksander@aleksander.es>