### PR TITLE
Fix 32-bit app crashing in 64-bit Android

### DIFF
--- a/gralloc_drm_handle.h
+++ b/gralloc_drm_handle.h
@@ -49,9 +49,9 @@ struct gralloc_drm_handle_t {
 
 	int name;   /* the name of the bo */
 	int stride; /* the stride in bytes */
-	uint64_t modifier; /* buffer modifiers */
-
 	int data_owner; /* owner of data (for validation) */
+
+	uint64_t modifier __attribute__((aligned(8))); /* buffer modifiers */
 	union {
 		void *data; /* pointer to struct gralloc_gbm_bo_t */
 		uint64_t reserved;


### PR DESCRIPTION
Seemingly the 64-bit int is always aligned to 8 in LP64.
But this is not hold in LP32.

Consequently sizeof(gralloc_drm_handle_t) are different
between LP64 (which is 18 ints) and LP32 (which is 16 ints).
As a result, 32-bit apps will crash in 64-bit OS since the
checking handle->base.numInts != GRALLOC_GBM_HANDLE_NUM_INTS
is true.

Fix it by always aligning 64-bit int to 8. Besides, to avoid
additional padding, just exchange the order of data_owner
and modifier. It aligns modifier to 8 natually.
This makes gralloc_drm_handle_t fit in 16 ints perfectly.

Signed-off-by: Chih-Wei Huang <cwhuang@linux.org.tw>