### PR TITLE
Remove gralloc.gbm.so in /system

### DIFF
--- a/CleanSpec.mk
+++ b/CleanSpec.mk
@@ -1,0 +1,2 @@
+$(call add-clean-step, rm -f $(PRODUCT_OUT)/system/lib*/libgralloc_drm.so)
+$(call add-clean-step, rm -f $(PRODUCT_OUT)/system/lib*/hw/gralloc.gbm.so)


### PR DESCRIPTION
Since commit 94559640 the libraries are moved to /vendor. But
the old libraries are not removed in an incremental build.
Therefore the new libraries may not be used.

Fixes: 94559640 ("Android: move libraries to /vendor")

Signed-off-by: Chih-Wei Huang <cwhuang@linux.org.tw>