### PR TITLE
replace delete with free

### DIFF
--- a/gralloc.cpp
+++ b/gralloc.cpp
@@ -194,7 +194,8 @@ static int gbm_mod_close_gpu0(struct hw_device_t *dev)
 	struct alloc_device_t *alloc = (struct alloc_device_t *) dev;
 
 	gbm_dev_destroy(dmod->gbm);
-	delete alloc;
+	native_handle_delete((native_handle*)handle);
+	//delete alloc;
 
 	return 0;
 }


### PR DESCRIPTION
"Native Handles" were originally allocated with the "malloc" call rather than the "new" operator.

Thus, it would make more sense to free the handles by "free" rather than the "delete" operator.
