### PR TITLE
gralloc_gbm: Handle null crop values

### DIFF
--- a/gralloc_gbm.cpp
+++ b/gralloc_gbm.cpp
@@ -428,6 +428,15 @@ int gralloc_gbm_bo_lock(buffer_handle_t handle,
 
 	usage |= bo_data->locked_for;
 
+	/*
+	 * Some users will lock with an null crop rect.
+	 * Interpret this as no-crop (full buffer WxH).
+	 */
+	if (w == 0 && h == 0) {
+		w = gbm_handle->width;
+		h = gbm_handle->height;
+	}
+
 	if (usage & (GRALLOC_USAGE_SW_WRITE_MASK |
 		     GRALLOC_USAGE_SW_READ_MASK)) {
 		/* the driver is supposed to wait for the bo */


### PR DESCRIPTION
Yongqin recently reported an issue here:
  https://bugs.linaro.org/show_bug.cgi?id=5566

Where the CTS VirtualDisplayTest is failing on db845c.

The trace looks like this:
    arm64-v8a CtsDisplayTestCases[instant]: Instrumentation run failed
due to 'Process crashed.'
Crash Message:lock buffer failed for format 0x1
java.lang.RuntimeException: lock buffer failed for format 0x1
    at android.media.ImageReader$SurfaceImage.nativeCreatePlanes(Native Method)
    at android.media.ImageReader$SurfaceImage.getPlanes(ImageReader.java:898)
    at android.display.cts.VirtualDisplayTest$ImageListener.scanImage(VirtualDisplayTest.java:381)
    at android.display.cts.VirtualDisplayTest$ImageListener.onImageAvailable(VirtualDisplayTest.java:364)
    at android.media.ImageReader$ListenerHandler.handleMessage(ImageReader.java:798)
    at android.os.Handler.dispatchMessage(Handler.java:106)
    at android.os.Looper.loop(Looper.java:216)
    at android.os.HandlerThread.run(HandlerThread.java:67)

What seems to be happening, is that the call chain looks like:

in frameworks/base/media/jni/android_media_ImageReader.cpp:
nativeCreatePlanes() ->
  Image_createSurfacePlanes() ->
    Image_getLockedImage() ->
frameworks/base/media/jni/android_media_Utils.cpp:
     lockImageFromBuffer():
Which then calls the other lockImageFromBuffer() with a uninitialized
bufferItem->mCrop value:
https://cs.android.com/android/platform/superproject/+/master:frameworks/base/media/jni/android_media_Utils.cpp;l=386

That then calls: buffer->lockAsync(inUsage, rect, &pData, fenceFd);
https://cs.android.com/android/platform/superproject/+/master:frameworks/base/media/jni/android_media_Utils.cpp;l=353

which calls into gralloc::lock() in the gralloc_gbm implementation.

gralloc_gbm::gralloc_gbm_bo_lock() calls gbm_map():
https://github.com/robherring/gbm_gralloc/blob/master/gralloc_gbm.cpp#L435

gralloc_gbm::gbm_map() calls gbm_bo_map():
https://github.com/robherring/gbm_gralloc/blob/master/gralloc_gbm.cpp#L284

Which returns an error if height or width is zero:
https://gitlab.freedesktop.org/mesa/mesa/-/blob/master/src/gbm/main/gbm.c#L560

While not common, since some users are passing null crop rects,
I propose we consider null crop rects to be the same as the
entire buffer.

Thus this patch special cases these null rects and changes the
width and height value to be the full buffer width and height.

With this patch, the affected CTS tests no longer fail.

Signed-off-by: John Stultz <john.stultz@linaro.org>