### PR TITLE
Add feature to search for KMS DRI card

### DIFF
--- a/gralloc_gbm.cpp
+++ b/gralloc_gbm.cpp
@@ -35,6 +35,8 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <assert.h>
+#include <xf86drmMode.h>
+#include <glob.h>
 
 #include <hardware/gralloc.h>
 #include <system/graphics.h>
@@ -311,13 +313,25 @@ struct gbm_device *gbm_dev_create(void)
 {
 	struct gbm_device *gbm;
 	char path[PROPERTY_VALUE_MAX];
+	int path_len;
 	int fd;
 
-	property_get("gralloc.gbm.device", path, "/dev/dri/renderD128");
-	fd = open(path, O_RDWR | O_CLOEXEC);
-	if (fd < 0) {
-		ALOGE("failed to open %s", path);
-		return NULL;
+	path_len = property_get("gralloc.gbm.device", path, "/dev/dri/card*");
+	/* Search for KMS device with the pattern or open it from property */
+	if (path[path_len - 1] == '*') {
+		fd = open_first_kms_dev(path);
+	} else {
+		fd = open(path, O_RDWR | O_CLOEXEC);
+	}
+
+	/* Open default path when KMS device wasn't found */
+	if (fd <= 0) {
+		strcpy(path, "/dev/dri/renderD128");
+		fd = open(path, O_RDWR | O_CLOEXEC);
+		if (fd < 0) {
+			ALOGE("failed to open %s with error %s", path, strerror(errno));
+			return NULL;
+		}
 	}
 
 	gbm = gbm_create_device(fd);
@@ -528,4 +542,55 @@ int gralloc_gbm_bo_lock_ycbcr(buffer_handle_t handle,
 	}
 
 	return 0;
+}
+
+/*
+ * Check if target device has KMS.
+ */
+bool is_kms_dev(int fd)
+{
+	auto res = drmModeGetResources(fd);
+	if (!res)
+		return false;
+
+	bool is_kms = res->count_crtcs > 0 && res->count_connectors > 0 &&
+			res->count_encoders > 0;
+
+	drmModeFreeResources(res);
+
+	return is_kms;
+}
+
+/*
+ * Search for a KMS device. Return opened file descriptor on success.
+ */
+int open_first_kms_dev(const char *pattern)
+{
+	glob_t glob_buf;
+	memset(&glob_buf, 0, sizeof(glob_buf));
+	int fd;
+
+	int ret = glob(pattern, 0, NULL, &glob_buf);
+	if (ret) {
+		globfree(&glob_buf);
+		return -EINVAL;
+	}
+
+	for (size_t i = 0; i < glob_buf.gl_pathc; ++i) {
+		fd = open(glob_buf.gl_pathv[i], O_RDWR | O_CLOEXEC);
+		if (fd < 0) {
+			ALOGE("failed to open %s with error %s", glob_buf.gl_pathv[i], strerror(errno));
+			continue;
+		}
+
+		if (is_kms_dev(fd))
+			break;
+
+		close(fd);
+		fd = 0;
+	}
+
+	globfree(&glob_buf);
+
+	return fd;
 }

--- a/gralloc_gbm_priv.h
+++ b/gralloc_gbm_priv.h
@@ -51,6 +51,9 @@ int gralloc_gbm_bo_lock_ycbcr(buffer_handle_t handle, int usage,
 struct gbm_device *gbm_dev_create(void);
 void gbm_dev_destroy(struct gbm_device *gbm);
 
+bool is_kms_dev(int fd);
+int open_first_kms_dev(const char *pattern);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Most modern SOCs have separate IP cores for GPU and Display Unit (KMS). To work properly mesa requires initialize gbm interface using KMS card. Mesa uses it to allocate buffers with SCANOUT flag and does not require fd or pathname explicitly specified for GPU. Mesa will search for GPU and load the proper driver.

Also, there is no warranty that the KMS card will always have /dev/dri/card0 path and GPU - /dev/dri/card1. Order can depend on many factors. For example: on the rpi4 board, it was observed that enabling the WIFI kernel module swapping the card order. Therefore searching for the KMS card is the only efficient solution.

The has_kms_dev function returns true when the libdrm function is returned resources and the target device has at least one CTRC, connector, and encoder. The open_first_kms_dev function returns opened file descriptor on success using the previous function to check for each device. It also returns zeroed value for the case of KMS absence, or the -EINVAL on glob function error.

In the case of absence of the "hwc.drm.device" system property the first KMS device or the default path /dev/dri/renderD128 will be used to open.

A similar solution has been created and merged for [drm-hwcomposer](https://gitlab.freedesktop.org/drm-hwcomposer/drm-hwcomposer/-/tree/main) ([MR#108](https://gitlab.freedesktop.org/drm-hwcomposer/drm-hwcomposer/-/merge_requests/108?commit_id=c7f2809dbc50e01d093b6d79045103104c22058d)).