### PR TITLE
Support getting offsets via lock_ycbcr()

### DIFF
--- a/gralloc_gbm.cpp
+++ b/gralloc_gbm.cpp
@@ -491,7 +491,7 @@ int gralloc_gbm_bo_lock_ycbcr(buffer_handle_t handle,
 {
 	struct gralloc_handle_t *hnd = gralloc_handle(handle);
 	int ystride, cstride;
-	void *addr;
+	void *addr = 0;
 	int err;
 
 	ALOGD("handle %p, hnd %p, usage 0x%x", handle, hnd, usage);


### PR DESCRIPTION
When no software access usage flag specified,
.lock_ycbcr() should return NULL pointer based plane addresses,
which mesa3d interprets as offsets.

Fixes 13c5034a859b ("gralloc_gbm: add .lock_ycbcr to support video playback use case")
