### PR TITLE
Add manifest fragment

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -40,6 +40,7 @@ LOCAL_MODULE := gralloc.gbm
 LOCAL_MODULE_TAGS := optional
 LOCAL_MODULE_RELATIVE_PATH := hw
 LOCAL_PROPRIETARY_MODULE := true
+LOCAL_VINTF_FRAGMENTS := gbm_gralloc_manifest.xml
 
 include $(BUILD_SHARED_LIBRARY)
 

--- a/gbm_gralloc_manifest.xml
+++ b/gbm_gralloc_manifest.xml
@@ -1,0 +1,20 @@
+<manifest version="1.0" type="device">
+    <hal format="hidl">
+        <name>android.hardware.graphics.allocator</name>
+        <transport>hwbinder</transport>
+        <version>2.0</version>
+        <interface>
+            <name>IAllocator</name>
+            <instance>default</instance>
+        </interface>
+    </hal>
+    <hal format="hidl">
+        <name>android.hardware.graphics.mapper</name>
+        <transport arch="32+64">passthrough</transport>
+        <version>2.1</version>
+        <interface>
+            <name>IMapper</name>
+            <instance>default</instance>
+        </interface>
+    </hal>
+</manifest>


### PR DESCRIPTION
Fragmented manifest is supported starting from Android-10.
Having it here makes easier to switch between different gralloc implementations.
