### PR TITLE
gbm_gralloc: libgbm ->  libgbm_mesa

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -28,7 +28,7 @@ LOCAL_SRC_FILES := \
 
 LOCAL_SHARED_LIBRARIES := \
 	libdrm \
-	libgbm \
+	libgbm_mesa \
 	liblog \
 	libcutils \
 	libhardware \


### PR DESCRIPTION
- The change [0] renamed the mesagbm module to gbm_mesa to avoid conflict with minigbm.

[0] - https://android.googlesource.com/platform/external/mesa3d/+/7036b3872f7853dc732fb557dcd9b4ca31887fd6%5E%21