### PR TITLE
gbm_gralloc: Add mesa libgbm to shared lib based on platform sdk version

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -28,10 +28,17 @@ LOCAL_SRC_FILES := \
 
 LOCAL_SHARED_LIBRARIES := \
 	libdrm \
-	libgbm \
 	liblog \
 	libcutils \
 	libhardware \
+
+ifeq ($(shell expr $(PLATFORM_SDK_VERSION) \>= 30), 1)
+LOCAL_SHARED_LIBRARIES += \
+        libgbm_mesa
+else
+LOCAL_SHARED_LIBRARIES += \
+        libgbm
+endif
 
 LOCAL_EXPORT_C_INCLUDE_DIRS := \
 	$(LOCAL_PATH)


### PR DESCRIPTION
- From Android 11, the mesa libgbm module renamed to libgbm_mesa to avoid conflict with minigbm.
  So Handle it correctly based on Platform SDK version.

[0] - https://android.googlesource.com/platform/external/mesa3d/+/7036b3872f7853dc732fb557dcd9b4ca31887fd6%5E%21

Signed-off-by: Dhina17 <dhinalogu@gmail.com>
Change-Id: I1d86f508a7729c8279d79a18666fb080be34745b