### PR TITLE
Map flexible YUV format to NV12

### DIFF
--- a/gralloc_gbm.cpp
+++ b/gralloc_gbm.cpp
@@ -103,6 +103,7 @@ static uint32_t get_gbm_format(int format)
 		break;
 	case HAL_PIXEL_FORMAT_YCbCr_422_SP:
 	case HAL_PIXEL_FORMAT_YCrCb_420_SP:
+	case HAL_PIXEL_FORMAT_YCbCr_420_888:
 	default:
 		fmt = 0;
 		break;
@@ -136,6 +137,7 @@ static int gralloc_gbm_get_bpp(int format)
 	case HAL_PIXEL_FORMAT_YV12:
 	case HAL_PIXEL_FORMAT_YCbCr_422_SP:
 	case HAL_PIXEL_FORMAT_YCrCb_420_SP:
+	case HAL_PIXEL_FORMAT_YCbCr_420_888:
 		bpp = 1;
 		break;
 	default:
@@ -497,6 +499,7 @@ int gralloc_gbm_bo_lock_ycbcr(buffer_handle_t handle,
 
 	switch (hnd->format) {
 	case HAL_PIXEL_FORMAT_YCrCb_420_SP:
+	case HAL_PIXEL_FORMAT_YCbCr_420_888:
 		ystride = cstride = GRALLOC_ALIGN(hnd->width, 16);
 		ycbcr->y = addr;
 		ycbcr->cr = (unsigned char *)addr + ystride * hnd->height;


### PR DESCRIPTION
The pixel format HAL_PIXEL_FORMAT_YCbCr_420_888 is used e.g. by WebView when accessing a webcam (maybe from NdkImageReader?). Simply mapping the flexible format to NV12 seems to do the trick on Baytrail platform.