### PR TITLE
gralloc_gbm: avoid SIGFPE for unsupported HAL pixel formats

### DIFF
--- a/gralloc_gbm.cpp
+++ b/gralloc_gbm.cpp
@@ -372,6 +372,11 @@ buffer_handle_t gralloc_gbm_bo_create(struct gbm_device *gbm,
 	struct gbm_bo *bo;
 	native_handle_t *handle;
 
+	if (gralloc_gbm_get_bpp(format) == 0) {
+		ALOGE("Failed to create gbm bo due to unsupported HAL pixel format: 0x%x", format);
+		return NULL;
+	}
+
 	handle = gralloc_handle_create(width, height, format, usage);
 	if (!handle)
 		return NULL;


### PR DESCRIPTION
gralloc_gbm_get_bpp() can return 0 for unsupported HAL pixel formats and this is causing segfaults with Android CTS 13 dEQP-EGL test runs due to division by zero

Checking bpp value before proceeding in gralloc_gbm_get_bpp() routines fixes the following segfaults observed with HAL Pixel Formats 0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x38

*** *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** Build fingerprint: 'Android-x86/android_x86_64/x86_64:13/TD1A.221105.001.A1/utente11130028:userdebug/test-keys' Revision: '0'
ABI: 'x86_64'
Timestamp: 2022-11-20 10:28:47.732248178+0100
Process uptime: 0s
Cmdline: /vendor/bin/hw/android.hardware.graphics.allocator@2.0-service pid: 2128, tid: 3271, name: HwBinder:2128_2  >>> /vendor/bin/hw/android.hardware.graphics.allocator@2.0-service <<< uid: 1000
signal 8 (SIGFPE), code 1 (FPE_INTDIV), fault addr 0x000074607665c2b5
    rax 0000000000000010  rbx 0000746146811cf0  rcx 0000000000000000  rdx 0000000000000000
    r8  0000746116816a40  r9  0000000000000005  r10 0000000000000002  r11 0000000000000002
    r12 0000000000000004  r13 0000000000000004  r14 000074607638f6a4  r15 000074613682ab60
    rdi 000074612682e590  rsi 000000000000002f
    rbp 0000746116816a30  rsp 000074607638f5b0  rip 000074607665c2b5

backtrace:
      00 pc 00000000000042b5  /system/vendor/lib64/hw/gralloc.gbm.so (gralloc_gbm_bo_create+613) (BuildId: 60d9fa52075d801263edce2d9f64aa57)
      01 pc 0000000000005926  /system/vendor/lib64/hw/gralloc.gbm.so (gbm_mod_alloc_gpu0(alloc_device_t*, int, int, int, int, native_handle const**, int*)+70) (BuildId: 60d9fa52075d801263edce2d9f64aa57)